### PR TITLE
fix: Adding 'ansible.posix' to requirements.yml

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -2,4 +2,7 @@
 collections:
   - name: 'community.general'
     version: '8.6.0'
+
+  - name: 'ansible.posix'
+    version: '1.5.4'
 ...


### PR DESCRIPTION
Hi,

The role needs the collection `ansible.posix` to work. Therefore added to requirements.yml.

Used version `1.5.4` since it was used for testing the first runs and worked fine.

Cheers,
Benny